### PR TITLE
Use shapeDrawer instead of ShapeRenderer and make all painting calls inside a single update method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ allprojects {
         box2DLightsVersion = '1.4'
         ashleyVersion = '1.7.0'
         aiVersion = '1.8.0'
+        shapedrawerVersion = '2.3.0'
     }
 
     repositories {
@@ -36,6 +37,7 @@ allprojects {
         google()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         maven { url "https://oss.sonatype.org/content/repositories/releases/" }
+        maven { url 'https://jitpack.io' }
     }
 }
 
@@ -48,7 +50,6 @@ project(":desktop") {
         api "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
         api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
         api "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
-        
     }
 }
 
@@ -65,6 +66,7 @@ project(":html") {
         api "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"
         api "com.badlogicgames.gdx:gdx-box2d:$gdxVersion:sources"
         api "com.badlogicgames.gdx:gdx-box2d-gwt:$gdxVersion:sources"
+        implementation "space.earlygrey:shapedrawer:$shapedrawerVersion:sources"
         
     }
 }
@@ -76,6 +78,6 @@ project(":core") {
     dependencies {
         api "com.badlogicgames.gdx:gdx:$gdxVersion"
         api "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
-        
+        implementation "space.earlygrey:shapedrawer:$shapedrawerVersion"
     }
 }

--- a/core/src/com/arco/towerdefense/game/controllers/GroundController.java
+++ b/core/src/com/arco/towerdefense/game/controllers/GroundController.java
@@ -1,14 +1,18 @@
 package com.arco.towerdefense.game.controllers;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector2;
+import space.earlygrey.shapedrawer.ShapeDrawer;
 
 import static com.arco.towerdefense.game.TowerDefenseGame.V_HEIGHT;
 
 public class GroundController {
+    private SpriteBatch batch;
     private Texture grassImg;
     private Texture laneImg;
     private int groundSize;
@@ -18,9 +22,14 @@ public class GroundController {
     private int viewportWidth;
     private int viewportHeight;
     Vector2 cursorLocation;
-    ShapeRenderer shapeRenderer;
 
-    public GroundController(String grassImgPath, String laneImgPath, int groundSize, int gridBlockSize, int viewWidth, int viewHeight) {
+    Texture texture;
+    TextureRegion region;
+    ShapeDrawer shapeDrawer;
+
+    public GroundController(SpriteBatch batch, String grassImgPath, String laneImgPath, int groundSize, int gridBlockSize, int viewWidth, int viewHeight) {
+        this.batch = batch;
+
         grassImg = new Texture(grassImgPath);
         laneImg = new Texture(laneImgPath);
 
@@ -33,7 +42,14 @@ public class GroundController {
 
         cursorLocation = new Vector2(0, 0);
 
-        shapeRenderer = new ShapeRenderer();
+        Pixmap pixmap = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
+        pixmap.setColor(Color.WHITE);
+        pixmap.drawPixel(0, 0);
+        texture = new Texture(pixmap); //remember to dispose of later
+        pixmap.dispose();
+        region = new TextureRegion(texture, 0, 0, 1, 1);
+
+        shapeDrawer = new ShapeDrawer(batch, region);
     }
 
     public int getGridWidth() {
@@ -44,16 +60,16 @@ public class GroundController {
         return viewportHeight / scale;
     }
 
-    public void paint(SpriteBatch batch) {
+    public void paint() {
         for(int x = 0; x <= this.getGridWidth(); x++) {
             for (int y = 0; y <= this.getGridHeight(); y++) {
-                drawGridBlock(x, y, grassImg, batch);
+                drawGridBlock(x, y, grassImg);
             }
         }
-        //drawLane(0, 1, 12, 1, batch);
+//        drawLane(0, 1, 12, 1, batch);
     }
 
-    private void drawGridBlock(int x, int y, Texture texture, SpriteBatch batch) {
+    private void drawGridBlock(int x, int y, Texture texture) {
         for (int i = 0; i < gridBlockSize; i++) {
             int realX = x*scale;
 
@@ -67,21 +83,24 @@ public class GroundController {
         }
     }
 
-    private void drawLane(int start_x, int start_y, int final_x, int final_y, SpriteBatch batch) {
+    private void drawLane(int start_x, int start_y, int final_x, int final_y) {
         if(start_x == final_x) {
             for(int y = start_y; y < final_y; y++) {
-                drawGridBlock(start_x, y, laneImg, batch);
+                drawGridBlock(start_x, y, laneImg);
             }
         }
 
         if(start_y == final_y) {
             for(int x = start_x; x < final_x; x++) {
-                drawGridBlock(x, start_y, laneImg, batch);
+                drawGridBlock(x, start_y, laneImg);
             }
         }
     }
 
     public void update() {
+
+        this.paint();
+
         cursorLocation.x = Gdx.input.getX();
         cursorLocation.y = V_HEIGHT - Gdx.input.getY();
 
@@ -90,10 +109,8 @@ public class GroundController {
                 int realx = x*scale;
                 int realy = y*scale;
                 if(cursorLocation.x >= realx-scale && cursorLocation.x <= realx && cursorLocation.y >= realy-scale && cursorLocation.y <= realy) {
-                    shapeRenderer.begin(ShapeRenderer.ShapeType.Line);
-                    shapeRenderer.setColor(1,0,0,1);
-                    shapeRenderer.rect(realx-scale, realy-scale, scale, scale);
-                    shapeRenderer.end();
+                    shapeDrawer.setColor(Color.RED);
+                    shapeDrawer.rectangle(realx-scale, realy-scale, scale, scale);
                 }
             }
         }
@@ -102,6 +119,6 @@ public class GroundController {
     public void dispose() {
         grassImg.dispose();
         laneImg.dispose();
-        shapeRenderer.dispose();
+        texture.dispose();
     }
 }

--- a/core/src/com/arco/towerdefense/game/screens/GameScreen.java
+++ b/core/src/com/arco/towerdefense/game/screens/GameScreen.java
@@ -18,7 +18,7 @@ public class GameScreen implements Screen {
 
     public GameScreen(TowerDefenseGame game) {
         this.game = game;
-        groundController = new GroundController("grasstop.png", "dirt.png", 16, 2, game.V_WIDTH, game.V_HEIGHT);
+        groundController = new GroundController(game.batch, "grasstop.png", "dirt.png", 16, 2, game.V_WIDTH, game.V_HEIGHT);
         mouse = new InputController();
     }
 
@@ -27,15 +27,8 @@ public class GameScreen implements Screen {
         Gdx.gl.glClearColor(0, 0, 0, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
         game.batch.begin();
-            groundController.paint(game.batch);
+            groundController.update();
         game.batch.end();
-
-        update();
-
-    }
-
-    public void update() {
-        groundController.update();
     }
 
     @Override

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jul 08 13:30:57 BRT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/html/src/com/arco/towerdefense/game/GdxDefinition.gwt.xml
+++ b/html/src/com/arco/towerdefense/game/GdxDefinition.gwt.xml
@@ -3,6 +3,7 @@
 <module rename-to="html">
 	<inherits name='com.badlogic.gdx.backends.gdx_backends_gwt' />
 	<inherits name='com.badlogic.gdx.physics.box2d.box2d-gwt' />
+	<inherits name="space.earlygrey.shapedrawer"/>
 
 	<inherits name='TowerDefenseGame' />
 	<entry-point class='com.arco.towerdefense.game.client.HtmlLauncher' />


### PR DESCRIPTION
Agora todo update no Ground vai ser feito no GroundController.update(); E o batch é passado no construtor pois vários métodos utilizam o mesmo, logo fica mais limpo se deixarmos como uma propriedade da classe, assim os métodos acessam facilmente.
Antes era:

    game.batch.begin();
            groundController.paint(game.batch);
    game.batch.end();

    update();
Onde o update() chamava o groundController.update() que ficava por unica função desenhar o quadrado vermelho no Ground. E isso era ideal pois não é possível usar o ShapeRenderer dentro de `batch#begin` e `batch#end`. Desse modo a gente teria que fazer o `batch#end` antes do `ShapeRenderer#begin` e isso custa performance. Por esse motivo agora vamos usar o ShapeDrawer que permite desenhar formas dentro do `batch#begin/end`.

ShapeDrawe docs: [https://github.com/earlygrey/shapedrawer](https://github.com/earlygrey/shapedrawer)