### PR TITLE
avoid multiple handle of clicks

### DIFF
--- a/core/src/com/arco/towerdefense/game/GameSingleton.java
+++ b/core/src/com/arco/towerdefense/game/GameSingleton.java
@@ -2,6 +2,7 @@ package com.arco.towerdefense.game;
 
 import com.arco.towerdefense.game.utils.Consts;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.math.Vector2;
@@ -11,6 +12,7 @@ public class GameSingleton {
 
     private Vector2 cursorLocation;
     public AssetManager assetManager;
+    private InputProcessor inputProcessor;
 
     private GameSingleton() {
         assetManager = new AssetManager();
@@ -52,6 +54,15 @@ public class GameSingleton {
         cursorLocation.y = Consts.V_HEIGHT - Gdx.input.getY();
 
         return cursorLocation;
+    }
+
+
+    public InputProcessor getInputProcessor() {
+        return inputProcessor;
+    }
+
+    public void setInputProcessor(InputProcessor inputProcessor) {
+        this.inputProcessor = inputProcessor;
     }
 
     public void dispose() {

--- a/core/src/com/arco/towerdefense/game/controllers/InteractionZoneController.java
+++ b/core/src/com/arco/towerdefense/game/controllers/InteractionZoneController.java
@@ -8,10 +8,11 @@ import com.arco.towerdefense.game.layouts.enums.Position;
 import com.arco.towerdefense.game.layouts.interfaces.LayoutListener;
 import com.arco.towerdefense.game.layouts.wrappers.LayoutWrapper;
 import com.arco.towerdefense.game.utils.Consts;
+import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 
-public class InteractionZoneController {
+public class InteractionZoneController extends InputAdapter {
     InteractionZoneDrawer interactionZoneDrawer;
     StackLayout stackSelectionTowers;
 
@@ -27,7 +28,6 @@ public class InteractionZoneController {
 
     public void update() {
         stackSelectionTowers.drawAtPos(Position.BOTTOM_LEFT);
-        handleMouse();
     }
 
     private void initSelectionTowers() {
@@ -70,9 +70,21 @@ public class InteractionZoneController {
         );
     }
 
-    private void handleMouse() {
+    @Override
+    public boolean touchUp(int screenX, int screenY, int pointer, int button) {
         if (stackSelectionTowers.isCursorInside()) {
-            stackSelectionTowers.handleMouse();
+            return stackSelectionTowers.handleTouchUp();
         }
+
+        return false;
+    }
+
+    @Override
+    public boolean mouseMoved(int screenX, int screenY) {
+        if (stackSelectionTowers.isCursorInside()) {
+            return stackSelectionTowers.handleMouseMoved();
+        }
+
+        return false;
     }
 }

--- a/core/src/com/arco/towerdefense/game/layouts/StackLayout.java
+++ b/core/src/com/arco/towerdefense/game/layouts/StackLayout.java
@@ -169,17 +169,27 @@ public class StackLayout {
         return Utils.isCursorInside(stackPosX, stackPosY, getWidth(), getHeight());
     }
 
-    public void handleMouse() {
-        // This function should be called only if we are sure that the cursor is inside
+    public boolean handleMouseMoved() {
+        // This function (handleTouchUp also) should be called only if we are sure that the cursor is inside
         // the StackLayout bounds for performance reasons.
         for(LayoutWrapper wrapper: wrappers) {
             if (Utils.isCursorInside(wrapper.sprite)) {
                 wrapper.triggerOnHover();
-
-                if (Gdx.input.isButtonJustPressed(Input.Buttons.LEFT)) {
-                    wrapper.triggerOnClick();
-                }
+                return true;
             }
         }
+
+        return false;
+    }
+
+    public boolean handleTouchUp() {
+        for(LayoutWrapper wrapper: wrappers) {
+            if (Utils.isCursorInside(wrapper.sprite)) {
+                wrapper.triggerOnClick();
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/core/src/com/arco/towerdefense/game/screens/GameScreen.java
+++ b/core/src/com/arco/towerdefense/game/screens/GameScreen.java
@@ -7,6 +7,7 @@ import com.arco.towerdefense.game.controllers.InteractionZoneController;
 import com.arco.towerdefense.game.utils.Consts;
 import com.arco.towerdefense.game.utils.Utils;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.*;
 
@@ -59,7 +60,11 @@ public class GameScreen implements Screen {
 
     @Override
     public void show() {
-
+        InputMultiplexer multiplexer = new InputMultiplexer();
+        multiplexer.addProcessor(interactionZoneController);
+        multiplexer.addProcessor(groundController);
+        GameSingleton.getInstance().setInputProcessor(Gdx.input.getInputProcessor());
+        Gdx.input.setInputProcessor(multiplexer);
     }
 
     @Override
@@ -74,6 +79,6 @@ public class GameScreen implements Screen {
 
     @Override
     public void hide() {
-
+        Gdx.input.setInputProcessor(GameSingleton.getInstance().getInputProcessor());
     }
 }

--- a/core/src/com/arco/towerdefense/game/utils/Utils.java
+++ b/core/src/com/arco/towerdefense/game/utils/Utils.java
@@ -6,12 +6,20 @@ import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 
 public class Utils {
+    private static Vector2 utilVector = new Vector2();
+
     public static boolean isCursorInside(float x, float y, float width, float height) {
         return (new Rectangle(x, y, width, height)).contains(GameSingleton.getInstance().getCursorLocation());
     }
 
     public static boolean isCursorInside(Sprite sprite) {
         return isCursorInside(sprite.getX(), sprite.getY(), sprite.getWidth(), sprite.getHeight());
+    }
+
+    public static boolean isInsideRectangle(Rectangle rect, float x, float y) {
+        utilVector.x = x;
+        utilVector.y = y;
+        return rect.contains(utilVector);
     }
 
     public static float getScreenCenterX() {


### PR DESCRIPTION
Agora os controllers extendem o InputAdapter (que por sua vez implementa o InputProcessor) e tratamos os eventos de input de interesse como touchUp e mouseMove por ordem. Antes dois controllers (GroundController e InteractionZoneController) estavam tratando o evento de click e isso acontecia pois eles usavam polling e agora estamos usando a ideia de observer, onde esperamos pelo evento e não checamos ele a todo momento. Com o InputMultiplexer a gente pode fazer com que quando o evento for tratado ele não seja propagado aos demais InputProcessors que foram adicionados no multiplexer. A ordem de adição é a ordem de precedencia:
```
        InputMultiplexer multiplexer = new InputMultiplexer();
        multiplexer.addProcessor(interactionZoneController);
        multiplexer.addProcessor(groundController);
        GameSingleton.getInstance().setInputProcessor(Gdx.input.getInputProcessor()); // Aqui salvamos o InputProcessor anterior pra restaurar ele quando sairmos dessa screen
        Gdx.input.setInputProcessor(multiplexer);
```